### PR TITLE
Security Fix

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:20-slim 
 
 WORKDIR /app
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -148,9 +148,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -14,6 +14,6 @@
   },
   "overrides": {
     "jsonwebtoken": "9.0.0",
-    "axios": "1.7.4"
+    "axios": "1.8.2"
   }
 }


### PR DESCRIPTION
### ref https://github.com/signalwire/cloud-product/issues/1473

This overrides Axios to 1.8.2(first patched) and locks the node image version to node20(last compatible)